### PR TITLE
docs(readme): add CONTRIBUTING.md references

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ The **Identity Service API** is a comprehensive, production-ready microservice f
 │   │   ├── position_schema.py
 │   │   ├── subcontractor_schema.py
 │   │   └── user_schema.py
-│   └── utils.py
+│   └── utils.py
 ├── CODE_OF_CONDUCT.md
 ├── COMMERCIAL-LICENSE.txt
+├── CONTRIBUTING.md
 ├── docker-entrypoint.sh
 ├── Dockerfile
 ├── env.example
@@ -463,6 +464,11 @@ For commercial use or support, contact: **bengeek06@gmail.com**
 
 ## Contributing
 
-See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for guidelines.
+We welcome contributions! Please read our contribution guidelines:
+
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Development workflow, coding standards, and pull request process
+- **[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)** - Community guidelines and expectations
+
+For the overall Waterfall project workflow and branch strategy, see the [main CONTRIBUTING.md](../../CONTRIBUTING.md) at the repository root.
 
 ---


### PR DESCRIPTION
## Description
Updates the README.md to properly reference the CONTRIBUTING.md file for better developer onboarding.

## Type of Change
- [x] Documentation update

## Changes Made
- Added CONTRIBUTING.md to the project structure tree
- Enhanced the Contributing section with clear references to:
  - Service-specific CONTRIBUTING.md (workflow, coding standards)
  - CODE_OF_CONDUCT.md (community guidelines)
  - Main CONTRIBUTING.md at repository root (global workflow)
- Improved developer experience by making contribution guidelines more discoverable

## Related Issue(s)
Fixes #DOC-001

## How Has This Been Tested?
- Verified markdown rendering locally
- Confirmed all links are valid
- Reviewed project structure accuracy

## Checklist
- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] Documentation has been updated
- [x] Changes generate no new warnings
- [x] Branch follows naming conventions (fix/DOC-001-add-contributing-reference)
- [x] Commit follows Conventional Commits format