### PR TITLE
fix: align description field max length to 255

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,6 @@ We welcome contributions! Please read our contribution guidelines:
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - Development workflow, coding standards, and pull request process
 - **[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)** - Community guidelines and expectations
 
-For the overall Waterfall project workflow and branch strategy, see the [main CONTRIBUTING.md](../../CONTRIBUTING.md) at the repository root.
+For the overall Waterfall project workflow and branch strategy, see the [main CONTRIBUTING.md](https://github.com/bengeek06/waterfall/blob/main/CONTRIBUTING.md) at the repository root.
 
 ---

--- a/app/schemas/company_schema.py
+++ b/app/schemas/company_schema.py
@@ -66,7 +66,7 @@ class CompanySchema(SQLAlchemyAutoSchema):
             validate.Length(min=1, max=100),
         ],
     )
-    description = fields.String(validate=validate.Length(max=200))
+    description = fields.String(validate=validate.Length(max=255))
     logo_url = fields.URL(allow_none=True, validate=validate.Length(max=255))
     website = fields.URL(allow_none=True, validate=validate.Length(max=255))
     phone_number = fields.String(

--- a/app/schemas/organization_unit_schema.py
+++ b/app/schemas/organization_unit_schema.py
@@ -75,7 +75,7 @@ class OrganizationUnitSchema(SQLAlchemyAutoSchema):
     description = fields.String(
         allow_none=True,
         validate=validate.Length(
-            max=200, error="Description cannot exceed 200 characters."
+            max=255, error="Description cannot exceed 255 characters."
         ),
     )
 

--- a/app/schemas/position_schema.py
+++ b/app/schemas/position_schema.py
@@ -57,7 +57,7 @@ class PositionSchema(SQLAlchemyAutoSchema):
 
     description = fields.String(
         validate=validate.Length(
-            max=200, error="Description cannot exceed 200 characters."
+            max=255, error="Description cannot exceed 255 characters."
         )
     )
 

--- a/app/schemas/subcontractor_schema.py
+++ b/app/schemas/subcontractor_schema.py
@@ -63,7 +63,7 @@ class SubcontractorSchema(SQLAlchemyAutoSchema):
     description = fields.String(
         required=False,
         validate=validate.Length(
-            max=200, error="Description cannot exceed 200 characters."
+            max=255, error="Description cannot exceed 255 characters."
         ),
     )
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -161,7 +161,7 @@ components:
           description: Associated company identifier (auto-assigned from JWT)
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the subcontractor
         contact_person:
           type: string
@@ -178,7 +178,7 @@ components:
           description: Email address of the subcontractor
         address:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Address of the subcontractor
         created_at:
           type: string
@@ -202,7 +202,7 @@ components:
           description: Name of the subcontractor
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the subcontractor
         contact_person:
           type: string
@@ -219,7 +219,7 @@ components:
           description: Email address of the subcontractor
         address:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Address of the subcontractor
 
     SubcontractorUpdate:
@@ -231,7 +231,7 @@ components:
           description: Name of the subcontractor
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the subcontractor
         contact_person:
           type: string
@@ -248,7 +248,7 @@ components:
           description: Email address of the subcontractor
         address:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Address of the subcontractor
     Position:
       type: object
@@ -268,7 +268,7 @@ components:
           description: Title or name of the position
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the position
         company_id:
           type: string
@@ -306,7 +306,7 @@ components:
           description: Title or name of the position
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the position
         organization_unit_id:
           type: string
@@ -328,7 +328,7 @@ components:
           description: Title or name of the position
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the position
         level:
           type: integer
@@ -344,7 +344,7 @@ components:
           description: Title or name of the position
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the position
         organization_unit_id:
           type: string
@@ -376,7 +376,7 @@ components:
           description: Associated company identifier (auto-assigned from JWT)
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the organization unit
         parent_id:
           type: string
@@ -413,7 +413,7 @@ components:
           description: Name of the organization unit
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the organization unit
         parent_id:
           type: string
@@ -430,7 +430,7 @@ components:
           description: Name of the organization unit
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the organization unit
         parent_id:
           type: string
@@ -453,7 +453,7 @@ components:
           description: Name of the company
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the company
         logo_url:
           type: string
@@ -512,7 +512,7 @@ components:
           description: Name of the company
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the company
         logo_url:
           type: string
@@ -559,7 +559,7 @@ components:
           description: Name of the company
         description:
           type: string
-          maxLength: 200
+          maxLength: 255
           description: Optional description of the company
         logo_url:
           type: string

--- a/tests/test_company.py
+++ b/tests/test_company.py
@@ -608,7 +608,7 @@ def test_patch_company_description_too_long(client, session):
     session.add(company)
     session.commit()
     response = client.patch(
-        f"/companies/{company.id}", json={"description": "x" * 201}
+        f"/companies/{company.id}", json={"description": "x" * 256}
     )
     assert response.status_code == 400
     data = response.get_json()


### PR DESCRIPTION
## Description
This PR fixes the inconsistency between database schema and validation for the `description` field across multiple resources.

## Changes
- Updated validation in schemas: Company, OrganizationUnit, Position, Subcontractor
- Changed `maxLength` from 200 to 255 to match DB constraints (`db.String(255)`)
- Updated OpenAPI specification to reflect the 255 character limit
- Updated test assertions to validate the new 255 character limit

## Impact
- **Breaking Change**: No - this is more permissive (allows more characters)
- **Database Migration**: Not required - DB already supports 255 chars
- **API Contract**: Updated to match actual database capacity

## Testing
- ✅ All 299 tests passing
- ✅ Updated test_patch_company_description_too_long to validate new limit
- ✅ Pylint score: 10.00/10
- ✅ Code formatted with black and isort

## Related Issues
Fixes #28