### PR TITLE
Fix: Correct environment variable names in /config endpoint

### DIFF
--- a/app/resources/config.py
+++ b/app/resources/config.py
@@ -40,15 +40,21 @@ class ConfigResource(Resource):
             dict: A dictionary containing the application configuration and
             HTTP status code 200.
         """
-        jwt_secret_is_set = os.getenv("JWT_SECRET_KEY") is not None
-        internal_secret_is_set = os.getenv("INTERNAL_SECRET_KEY") is not None
+        jwt_secret_is_set = os.getenv("JWT_SECRET") is not None
+        internal_auth_token_is_set = os.getenv("INTERNAL_AUTH_TOKEN") is not None
 
         config = {
             "FLASK_ENV": os.getenv("FLASK_ENV"),
             "LOG_LEVEL": os.getenv("LOG_LEVEL"),
-            "DATABASE_URI": os.getenv("DATABASE_URI"),
+            "DATABASE_URL": os.getenv("DATABASE_URL"),
+            "USE_GUARDIAN_SERVICE": os.getenv("USE_GUARDIAN_SERVICE"),
             "GUARDIAN_SERVICE_URL": os.getenv("GUARDIAN_SERVICE_URL"),
-            "JWT_SECRET": jwt_secret_is_set,
-            "INTERNAL_AUTH_TOKEN": internal_secret_is_set,
+            "GUARDIAN_SERVICE_TIMEOUT": os.getenv("GUARDIAN_SERVICE_TIMEOUT"),
+            "USE_STORAGE_SERVICE": os.getenv("USE_STORAGE_SERVICE"),
+            "STORAGE_SERVICE_URL": os.getenv("STORAGE_SERVICE_URL"),
+            "STORAGE_REQUEST_TIMEOUT": os.getenv("STORAGE_REQUEST_TIMEOUT"),
+            "MAX_AVATAR_SIZE_MB": os.getenv("MAX_AVATAR_SIZE_MB"),
+            "JWT_SECRET_SET": jwt_secret_is_set,
+            "INTERNAL_AUTH_TOKEN_SET": internal_auth_token_is_set,
         }
         return config, 200

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -33,6 +33,26 @@ def test_config_endpoit(client):
 
     data = json.loads(response.data)
     assert isinstance(data, dict)
+
+    # Core environment variables
     assert "FLASK_ENV" in data
     assert "LOG_LEVEL" in data
-    assert "DATABASE_URI" in data
+    assert "DATABASE_URL" in data
+
+    # Guardian Service configuration
+    assert "USE_GUARDIAN_SERVICE" in data
+    assert "GUARDIAN_SERVICE_URL" in data
+    assert "GUARDIAN_SERVICE_TIMEOUT" in data
+
+    # Storage Service configuration
+    assert "USE_STORAGE_SERVICE" in data
+    assert "STORAGE_SERVICE_URL" in data
+    assert "STORAGE_REQUEST_TIMEOUT" in data
+    assert "MAX_AVATAR_SIZE_MB" in data
+
+    # Security tokens (should only show if set, not the actual values)
+    assert "JWT_SECRET_SET" in data
+    assert "INTERNAL_AUTH_TOKEN_SET" in data
+    assert isinstance(data["JWT_SECRET_SET"], bool)
+    assert isinstance(data["INTERNAL_AUTH_TOKEN_SET"], bool)
+


### PR DESCRIPTION
Closes #18

## 🐛 Problem

The `/config` endpoint was reading environment variables with incorrect names, causing all values to return `null` or `false`:
- Used `DATABASE_URI` instead of `DATABASE_URL`
- Used `JWT_SECRET_KEY` instead of `JWT_SECRET`
- Used `INTERNAL_SECRET_KEY` instead of `INTERNAL_AUTH_TOKEN`
- Missing several new environment variables

## ✅ Solution

### Fixed Variable Names
- ✅ `DATABASE_URI` → `DATABASE_URL` (matches docker-compose)
- ✅ `JWT_SECRET_KEY` → `JWT_SECRET` (matches docker-compose)
- ✅ `INTERNAL_SECRET_KEY` → `INTERNAL_AUTH_TOKEN` (matches docker-compose)

### Added Missing Variables
- ✅ `USE_GUARDIAN_SERVICE`
- ✅ `GUARDIAN_SERVICE_TIMEOUT`
- ✅ `USE_STORAGE_SERVICE`
- ✅ `STORAGE_SERVICE_URL`
- ✅ `STORAGE_REQUEST_TIMEOUT`
- ✅ `MAX_AVATAR_SIZE_MB`

### Improved Response Keys
- `JWT_SECRET` → `JWT_SECRET_SET` (boolean indicator for clarity)
- `INTERNAL_AUTH_TOKEN` → `INTERNAL_AUTH_TOKEN_SET` (boolean indicator for clarity)

## 🧪 Testing
- ✅ Updated `test_config.py` to validate all fields
- ✅ All tests passing
- ✅ Pylint score: 9.71/10

## 📝 Files Changed
- `app/resources/config.py` - Fixed environment variable names and added missing ones
- `tests/unit/test_config.py` - Added comprehensive assertions for all config fields