### PR TITLE
docs: Mark company_id as required in User schema (Issue #26 follow-up)

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -687,6 +687,7 @@ components:
       type: object
       required:
         - email
+        - company_id
       properties:
         id:
           type: string


### PR DESCRIPTION
## Follow-up to Issue #26 (PR #47)

### Context
PR #47 made `company_id` NOT NULL at the database level, but the OpenAPI specification was not updated to reflect this requirement.

### Changes
✅ Added `company_id` to the `required` list in the `User` schema

### OpenAPI Update
```yaml
User:
  type: object
  required:
    - email
    - company_id  # NEW: Now required
  properties:
    company_id:
      type: string
      format: uuid
      readOnly: true  # Still readOnly (auto-assigned from JWT)
      description: Associated company identifier (auto-assigned from JWT)
```

### Why This Matters
- **API Consumers**: Client applications can rely on `company_id` always being present in User responses
- **Documentation Accuracy**: OpenAPI spec now matches actual database constraints
- **Type Safety**: Code generators will mark this field as non-optional

### Note
`company_id` remains `readOnly: true` because:
- It's automatically assigned from the JWT token
- Users cannot set or modify it via API requests
- But it's now guaranteed to be present in all responses

### Related
- Issue #26: Security: Superuser creation with nullable company_id is dangerous
- PR #47: fix: Remove nullable company_id security vulnerability