### PR TITLE
fix: Update GitHub Actions to run on main, staging, and develop branches

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches: [ main, fix_issues ]
+    branches: [ main, staging, develop ]
     paths:
       - "Dockerfile"
       - "**/*.py"
@@ -10,7 +10,7 @@ on:
       - "requirements-dev.txt"
       - ".github/workflows/docker-image.yml"
   pull_request:
-    branches: [ main ]
+    branches: [ main, staging, develop ]
 
 permissions:
   contents: read
@@ -118,6 +118,10 @@ jobs:
             if [ -n "${{ steps.meta.outputs.version_tag }}" ]; then
               TAGS="${TAGS},${IMAGE}:${{ steps.meta.outputs.version_tag }}"
             fi
+          elif [ "${{ github.ref }}" = "refs/heads/staging" ]; then
+            TAGS="${TAGS},${IMAGE}:staging"
+          elif [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            TAGS="${TAGS},${IMAGE}:develop"
           fi
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,9 +2,9 @@ name: Flask service
 
 on:
   push:
-    branches: [ main, guardian_staging ]
+    branches: [ main, staging, develop ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ main, staging, develop ]
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10",  "3.11",  "3.12", "3.13"]
+        python-version: ["3.11",  "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -46,5 +46,11 @@ jobs:
         MAX_AVATAR_SIZE_MB=5
         USE_STORAGE_SERVICE=false
         USE_GUARDIAN_SERVICE=false
+        USE_EMAIL_SERVICE=false
+        MAIL_SERVER=localhost
+        MAIL_PORT=587
+        MAIL_USERNAME=test@example.com
+        MAIL_PASSWORD=test-password
+        MAIL_DEFAULT_SENDER=noreply@test.com
         EOF
         pytest tests/unit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Identity Service API
 
-[![Tests](https://github.com/bengeek06/pm-identity-api/actions/workflows/python-app.yml/badge.svg?branch=guardian_staging)](https://github.com/bengeek06/pm-identity-api/actions)
+[![Tests](https://github.com/bengeek06/pm-identity-api/actions/workflows/python-app.yml/badge.svg?branch=develop)](https://github.com/bengeek06/pm-identity-api/actions)
 [![License: AGPL v3 / Commercial](https://img.shields.io/badge/license-AGPLv3%20%2F%20Commercial-blue)](LICENSE.md)
 [![OpenAPI Spec](https://img.shields.io/badge/OpenAPI-3.0.3-blue.svg)](openapi.yml)
 ![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)


### PR DESCRIPTION
## Changes

- ✅ Update workflow triggers to run on `main`, `staging`, and `develop` branches
- ✅ Remove Python 3.10 from test matrix (EOL October 2026)
- ✅ Add email environment variables to test configuration
- ✅ Improve Docker image tagging strategy:
  - `main` → `latest` + version tag
  - `staging` → `staging`
  - `develop` → `develop`
  - All branches → `sha-XXXXXXX`
- ✅ Fix README badge to point to `develop` branch

## Testing

- [ ] Verify workflows run on develop branch
- [ ] Verify workflows run on staging branch
- [ ] Verify workflows run on main branch
- [ ] Check Docker image tags are correctly generated

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
