### PR TITLE
fix: Align Permission schema with Guardian spec (Issue #58)

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -919,7 +919,7 @@ components:
         - id
         - service
         - resource_name
-        - operations
+        - operation
       properties:
         id:
           type: string
@@ -935,11 +935,10 @@ components:
           type: string
           nullable: true
           description: Optional description of the permission
-        operations:
-          type: array
-          items:
-            type: string
-          description: List of operations allowed by this permission
+        operation:
+          type: string
+          enum: [LIST, CREATE, READ, UPDATE, DELETE]
+          description: Operation allowed by this permission (SINGULAR UPPERCASE as per Guardian spec)
         company_id:
           type: string
           format: uuid


### PR DESCRIPTION
## Description

This PR fixes Issue #58 by aligning the Identity service OpenAPI spec with the Guardian service specification for permissions.

## Problem

Identity OpenAPI spec had an inconsistency with Guardian:
- **Identity spec**: `operations` (array of strings, plural)
- **Guardian spec**: `operation` (single string UPPERCASE, singular)

Since Guardian is the authoritative service for permissions, Identity must align with Guardian's format.

## Changes

### OpenAPI Spec Update (`openapi.yml`)

**Permission schema:**
- ✅ Changed `operations` (array) → `operation` (string)
- ✅ Added enum constraint: `[LIST, CREATE, READ, UPDATE, DELETE]`
- ✅ Updated description to clarify SINGULAR UPPERCASE format
- ✅ Updated required fields

### Verification

All list endpoints already return the correct format:
- ✅ GET /users → `{data: [...], pagination: {...}}`
- ✅ GET /companies → `{data: [...], pagination: {...}}`
- ✅ GET /positions → `{data: [...], pagination: {...}}`
- ✅ GET /organization_units → `{data: [...], pagination: {...}}`
- ✅ GET /customers → `{data: [...], pagination: {...}}`
- ✅ GET /subcontractors → `{data: [...], pagination: {...}}`

The backend code (`user_permissions.py`) already returns permissions as received from Guardian, so no backend changes needed.

## Impact

- OpenAPI spec now correctly documents Guardian's permission format
- Frontend already handles this format (from `feature/update-api-backend-evolution`)
- No backend code changes required (Identity proxies Guardian responses)

Fixes #58