### PR TITLE
feat: Enrich user roles with full role objects from Guardian (Issue #64)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,15 +18,16 @@ Functions:
 """
 
 import os
-from flask import Flask, request, g
-from flask_migrate import Migrate
-from flask_marshmallow import Marshmallow
-from flask_cors import CORS
 
-from app.models import db
+from flask import Flask, g, request
+from flask_cors import CORS
+from flask_marshmallow import Marshmallow
+from flask_migrate import Migrate
+
 from app.logger import logger
-from app.routes import register_routes
+from app.models import db
 from app.models.user import User
+from app.routes import register_routes
 
 # Initialize Flask extensions
 migrate = Migrate()
@@ -222,7 +223,9 @@ def create_app(config_class):
     env = os.getenv("FLASK_ENV", "development")
     logger.info("Creating app in environment.", environment=env)
     if env in ("development", "staging"):
-        CORS(app, supports_credentials=True, resources={r"/*": {"origins": "*"}})
+        CORS(
+            app, supports_credentials=True, resources={r"/*": {"origins": "*"}}
+        )
 
     register_extensions(app)
     register_error_handlers(app)

--- a/app/logger.py
+++ b/app/logger.py
@@ -15,8 +15,9 @@ Usage:
     logger.info("Your log message", extra_field="value")
 """
 
-import os
 import logging
+import os
+
 import colorlog
 import structlog
 

--- a/app/models/company.py
+++ b/app/models/company.py
@@ -10,9 +10,11 @@ system.
 """
 
 import uuid
+
 from sqlalchemy.exc import SQLAlchemyError
-from app.models import db
+
 from app.logger import logger
+from app.models import db
 
 
 class Company(db.Model):
@@ -46,7 +48,9 @@ class Company(db.Model):
 
     __tablename__ = "company"
 
-    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id = db.Column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
     name = db.Column(db.String(100), nullable=False)
     description = db.Column(db.String(255), nullable=True)
     logo_url = db.Column(db.String(255), nullable=True)

--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -10,9 +10,11 @@ company.
 """
 
 import uuid
+
 from sqlalchemy.exc import SQLAlchemyError
-from app.models import db
+
 from app.logger import logger
+from app.models import db
 
 
 class Customer(db.Model):
@@ -37,9 +39,13 @@ class Customer(db.Model):
 
     __tablename__ = "customer"
 
-    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id = db.Column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
     name = db.Column(db.String(100), nullable=False)
-    company_id = db.Column(db.String(36), db.ForeignKey("company.id"), nullable=False)
+    company_id = db.Column(
+        db.String(36), db.ForeignKey("company.id"), nullable=False
+    )
     email = db.Column(db.String(100), nullable=True, unique=True)
     contact_person = db.Column(db.String(100), nullable=True)
     phone_number = db.Column(db.String(50), nullable=True)
@@ -110,7 +116,9 @@ class Customer(db.Model):
         try:
             return cls.query.filter_by(company_id=company_id).all()
         except SQLAlchemyError as e:
-            logger.error(f"Error retrieving customers by company ID {company_id}: {e}")
+            logger.error(
+                f"Error retrieving customers by company ID {company_id}: {e}"
+            )
             return []
 
     @classmethod

--- a/app/models/organization_unit.py
+++ b/app/models/organization_unit.py
@@ -10,9 +10,11 @@ as a department or division.
 """
 
 import uuid
+
 from sqlalchemy.exc import SQLAlchemyError
-from app.models import db
+
 from app.logger import logger
+from app.models import db
 
 
 class OrganizationUnit(db.Model):
@@ -40,9 +42,13 @@ class OrganizationUnit(db.Model):
 
     __tablename__ = "organization_unit"
 
-    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id = db.Column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
     name = db.Column(db.String(100), nullable=False)
-    company_id = db.Column(db.String(36), db.ForeignKey("company.id"), nullable=False)
+    company_id = db.Column(
+        db.String(36), db.ForeignKey("company.id"), nullable=False
+    )
     description = db.Column(db.String(255), nullable=True)
     parent_id = db.Column(
         db.String(36), db.ForeignKey("organization_unit.id"), nullable=True
@@ -99,7 +105,9 @@ class OrganizationUnit(db.Model):
         try:
             return cls.query.filter_by(id=unit_id).first()
         except SQLAlchemyError as e:
-            logger.error(f"Error retrieving organization unit by ID {unit_id}: {e}")
+            logger.error(
+                f"Error retrieving organization unit by ID {unit_id}: {e}"
+            )
             return None
 
     @classmethod
@@ -116,7 +124,9 @@ class OrganizationUnit(db.Model):
         try:
             return cls.query.filter_by(name=name).first()
         except SQLAlchemyError as e:
-            logger.error(f"Error retrieving organization unit by name {name}: {e}")
+            logger.error(
+                f"Error retrieving organization unit by name {name}: {e}"
+            )
             return None
 
     @classmethod
@@ -133,7 +143,9 @@ class OrganizationUnit(db.Model):
         try:
             return cls.query.filter_by(company_id=company_id).all()
         except SQLAlchemyError as e:
-            logger.error(f"Error retrieving org units for company ID {company_id}: {e}")
+            logger.error(
+                f"Error retrieving org units for company ID {company_id}: {e}"
+            )
             return []
 
     @classmethod
@@ -151,7 +163,9 @@ class OrganizationUnit(db.Model):
         try:
             return cls.query.filter_by(parent_id=parent_id).all()
         except SQLAlchemyError as e:
-            logger.error("Error retrieving children for parent ID %s: %s", parent_id, e)
+            logger.error(
+                "Error retrieving children for parent ID %s: %s", parent_id, e
+            )
             return []
 
     def update_path_and_level(self):

--- a/app/models/position.py
+++ b/app/models/position.py
@@ -10,9 +10,11 @@ or title.
 """
 
 import uuid
+
 from sqlalchemy.exc import SQLAlchemyError
-from app.models import db
+
 from app.logger import logger
+from app.models import db
 
 
 class Position(db.Model):
@@ -37,9 +39,13 @@ class Position(db.Model):
 
     __tablename__ = "position"
 
-    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id = db.Column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
     title = db.Column(db.String(100), nullable=False)
-    company_id = db.Column(db.String(36), db.ForeignKey("company.id"), nullable=False)
+    company_id = db.Column(
+        db.String(36), db.ForeignKey("company.id"), nullable=False
+    )
     organization_unit_id = db.Column(
         db.String(36), db.ForeignKey("organization_unit.id"), nullable=False
     )
@@ -114,7 +120,9 @@ class Position(db.Model):
         try:
             return cls.query.filter_by(company_id=company_id).all()
         except SQLAlchemyError as e:
-            logger.error(f"Error retrieving positions for company {company_id}: {e}")
+            logger.error(
+                f"Error retrieving positions for company {company_id}: {e}"
+            )
             return []
 
     @classmethod
@@ -148,7 +156,9 @@ class Position(db.Model):
                             organization unit.
         """
         try:
-            return cls.query.filter_by(organization_unit_id=organization_unit_id).all()
+            return cls.query.filter_by(
+                organization_unit_id=organization_unit_id
+            ).all()
         except SQLAlchemyError as e:
             logger.error(
                 "Error retrieving positions for organization unit %s: %s",

--- a/app/models/subcontractor.py
+++ b/app/models/subcontractor.py
@@ -10,9 +10,11 @@ company.
 """
 
 import uuid
+
 from sqlalchemy.exc import SQLAlchemyError
-from app.models import db
+
 from app.logger import logger
+from app.models import db
 
 
 class Subcontractor(db.Model):
@@ -39,9 +41,13 @@ class Subcontractor(db.Model):
 
     __tablename__ = "subcontractor"
 
-    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id = db.Column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
     name = db.Column(db.String(100), nullable=False)
-    company_id = db.Column(db.String(36), db.ForeignKey("company.id"), nullable=False)
+    company_id = db.Column(
+        db.String(36), db.ForeignKey("company.id"), nullable=False
+    )
     description = db.Column(db.String(255), nullable=True)
     contact_person = db.Column(db.String(100), nullable=True)
     phone_number = db.Column(db.String(50), nullable=True)
@@ -139,5 +145,7 @@ class Subcontractor(db.Model):
         try:
             return cls.query.filter_by(name=name).first()
         except SQLAlchemyError as e:
-            logger.error("Error retrieving subcontractor by name %s: %s", name, e)
+            logger.error(
+                "Error retrieving subcontractor by name %s: %s", name, e
+            )
             return None

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -8,13 +8,14 @@ attributes, relationships, and utility methods for CRUD operations.
 The User model represents an individual user account within a company.
 """
 
-import uuid
 import enum
+import uuid
 
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.security import check_password_hash
-from app.models import db
+
 from app.logger import logger
+from app.models import db
 
 
 class LanguageEnum(enum.Enum):
@@ -52,12 +53,16 @@ class User(db.Model):
 
     __tablename__ = "user"
 
-    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id = db.Column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
     email = db.Column(db.String(100), nullable=False, unique=True)
     hashed_password = db.Column(db.String(255), nullable=False)
     first_name = db.Column(db.String(50), nullable=True)
     last_name = db.Column(db.String(50), nullable=True)
-    language = db.Column(db.Enum(LanguageEnum), default=LanguageEnum.EN, nullable=False)
+    language = db.Column(
+        db.Enum(LanguageEnum), default=LanguageEnum.EN, nullable=False
+    )
     phone_number = db.Column(db.String(50), nullable=True)
     avatar_url = db.Column(db.String(255), nullable=True)
     is_active = db.Column(db.Boolean, default=True)
@@ -67,7 +72,9 @@ class User(db.Model):
     company_id = db.Column(
         db.String(36), db.ForeignKey("company.id"), nullable=True, index=True
     )
-    position_id = db.Column(db.String(36), db.ForeignKey("position.id"), nullable=True)
+    position_id = db.Column(
+        db.String(36), db.ForeignKey("position.id"), nullable=True
+    )
     created_at = db.Column(db.DateTime, default=db.func.current_timestamp())
     updated_at = db.Column(
         db.DateTime,
@@ -136,7 +143,9 @@ class User(db.Model):
         try:
             return cls.query.filter_by(email=email).first()
         except SQLAlchemyError as e:
-            logger.error("Error retrieving user by email %s: %s", email, str(e))
+            logger.error(
+                "Error retrieving user by email %s: %s", email, str(e)
+            )
             return None
 
     @classmethod

--- a/app/resources/__init__.py
+++ b/app/resources/__init__.py
@@ -9,8 +9,8 @@ are available for use throughout the application, including for database
 migrations, relationships, and resource definitions.
 """
 
-from app.models.user import User
-from app.models.organization_unit import OrganizationUnit
 from app.models.company import Company
-from app.models.position import Position
 from app.models.customer import Customer
+from app.models.organization_unit import OrganizationUnit
+from app.models.position import Position
+from app.models.user import User

--- a/app/resources/company.py
+++ b/app/resources/company.py
@@ -10,16 +10,15 @@ validation and serialization, and handle database errors gracefully.
 """
 
 from flask import request
+from flask_restful import Resource
 from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from flask_restful import Resource
 
-from app.models import db
 from app.logger import logger
-
+from app.models import db
 from app.models.company import Company
 from app.schemas.company_schema import CompanySchema
-from app.utils import require_jwt_auth, check_access_required
+from app.utils import check_access_required, require_jwt_auth
 
 
 class CompanyListResource(Resource):
@@ -157,7 +156,9 @@ class CompanyResource(Resource):
             logger.warning("Company with ID %s not found", company_id)
             return {"message": "Company not found"}, 404
 
-        company_schema = CompanySchema(context={"company": company}, session=db.session)
+        company_schema = CompanySchema(
+            context={"company": company}, session=db.session
+        )
 
         try:
             company = company_schema.load(json_data, instance=company)

--- a/app/resources/config.py
+++ b/app/resources/config.py
@@ -7,8 +7,10 @@ configuration through a REST endpoint.
 """
 
 import os
+
 from flask_restful import Resource
-from app.utils import require_jwt_auth, check_access_required
+
+from app.utils import check_access_required, require_jwt_auth
 
 
 class ConfigResource(Resource):

--- a/app/resources/customer.py
+++ b/app/resources/customer.py
@@ -9,17 +9,16 @@ updating, and deleting customers. The resources use Marshmallow schemas for
 validation and serialization, and handle database errors gracefully.
 """
 
-from flask import request, g
+from flask import g, request
+from flask_restful import Resource
 from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from flask_restful import Resource
 
-from app.models import db
 from app.logger import logger
-
+from app.models import db
 from app.models.customer import Customer
 from app.schemas.customer_schema import CustomerSchema
-from app.utils import require_jwt_auth, check_access_required
+from app.utils import check_access_required, require_jwt_auth
 
 
 class CustomerListResource(Resource):
@@ -157,7 +156,9 @@ class CustomerResource(Resource):
                 logger.warning("Customer with ID %s not found", customer_id)
                 return {"error": "Customer not found"}, 404
 
-            updated_customer = customer_schema.load(json_data, instance=customer)
+            updated_customer = customer_schema.load(
+                json_data, instance=customer
+            )
             db.session.commit()
             return customer_schema.dump(updated_customer), 200
         except ValidationError as err:

--- a/app/resources/health.py
+++ b/app/resources/health.py
@@ -7,9 +7,11 @@ This module provides a simple health check endpoint to verify that the service i
 
 import os
 from datetime import datetime, timezone
+
 from flask_restful import Resource
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
+
 from app.logger import logger
 from app.models import db
 from app.resources.version import API_VERSION
@@ -42,7 +44,9 @@ class HealthResource(Resource):
         health_data = {
             "status": "healthy",
             "service": "identity_service",
-            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "timestamp": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
             "version": API_VERSION,
             "environment": os.getenv("FLASK_ENV", "development"),
             "checks": {},
@@ -74,7 +78,9 @@ class HealthResource(Resource):
 
             # Check if result is as expected
             if result.scalar() == 1:
-                response_time_ms = (end_time - start_time).total_seconds() * 1000
+                response_time_ms = (
+                    end_time - start_time
+                ).total_seconds() * 1000
                 return {
                     "healthy": True,
                     "message": "Database connection successful",

--- a/app/resources/init_db.py
+++ b/app/resources/init_db.py
@@ -29,16 +29,14 @@ from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from werkzeug.security import generate_password_hash
 
-from app.models import db
 from app.logger import logger
-
-from app.models.user import User
+from app.models import db
 from app.models.company import Company
-
+from app.models.user import User
 from app.schemas.company_schema import CompanySchema
-from app.schemas.user_schema import UserSchema
 from app.schemas.organization_unit_schema import OrganizationUnitSchema
 from app.schemas.position_schema import PositionSchema
+from app.schemas.user_schema import UserSchema
 
 
 class InitDBResource(Resource):
@@ -166,7 +164,9 @@ class InitDBResource(Resource):
             "name": "default organization",
             "company_id": company_id,
         }
-        logger.info(f"default_org_unit_data type: {type(default_org_unit_data)}")
+        logger.info(
+            f"default_org_unit_data type: {type(default_org_unit_data)}"
+        )
         logger.info("Creating default organization unit.")
         new_org_unit = org_unit_schema.load(default_org_unit_data)
         db.session.add(new_org_unit)
@@ -191,7 +191,9 @@ class InitDBResource(Resource):
             "company_id": company_id,
             "organization_unit_id": org_unit_id,
         }
-        logger.info(f"default_position_data type: {type(default_position_data)}")
+        logger.info(
+            f"default_position_data type: {type(default_position_data)}"
+        )
         logger.info("Creating default position.")
         new_position = position_schema.load(default_position_data)
         db.session.add(new_position)
@@ -221,11 +223,15 @@ class InitDBResource(Resource):
         user_data["position_id"] = position_id
 
         if "password" in user_data:
-            user_data["hashed_password"] = generate_password_hash(user_data["password"])
+            user_data["hashed_password"] = generate_password_hash(
+                user_data["password"]
+            )
             del user_data["password"]
         else:
             logger.error("User data missing 'password' field.")
-            raise ValidationError({"password": ["Missing data for required field."]})
+            raise ValidationError(
+                {"password": ["Missing data for required field."]}
+            )
 
         new_user = user_schema.load(user_data)
         new_user.company_id = company_id
@@ -313,7 +319,9 @@ class InitDBResource(Resource):
         try:
             with db.session.begin_nested():
                 # Create all entities in order
-                new_company = self._create_company(company_data, company_schema)
+                new_company = self._create_company(
+                    company_data, company_schema
+                )
                 new_org_unit = self._create_organization_unit(
                     new_company.id, org_unit_schema
                 )

--- a/app/resources/organization_unit.py
+++ b/app/resources/organization_unit.py
@@ -11,15 +11,15 @@ handle database errors gracefully.
 """
 
 from flask import request
+from flask_restful import Resource
 from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from flask_restful import Resource
 
-from app.models import db
 from app.logger import logger
+from app.models import db
 from app.models.organization_unit import OrganizationUnit
 from app.schemas.organization_unit_schema import OrganizationUnitSchema
-from app.utils import require_jwt_auth, check_access_required
+from app.utils import check_access_required, require_jwt_auth
 
 
 class OrganizationUnitListResource(Resource):
@@ -81,7 +81,9 @@ class OrganizationUnitListResource(Resource):
             return {"error": str(err)}, 400
         except IntegrityError as err:
             db.session.rollback()
-            logger.error("Integrity error, possibly duplicate entry: %s", str(err))
+            logger.error(
+                "Integrity error, possibly duplicate entry: %s", str(err)
+            )
             return {"error": "Integrity error, possibly duplicate entry."}, 400
         except SQLAlchemyError as err:
             db.session.rollback()
@@ -158,10 +160,14 @@ class OrganizationUnitResource(Resource):
         try:
             org_unit = OrganizationUnit.get_by_id(unit_id)
             if not org_unit:
-                logger.warning("Organization unit with ID %s not found", unit_id)
+                logger.warning(
+                    "Organization unit with ID %s not found", unit_id
+                )
                 return {"error": "Organization unit not found"}, 404
 
-            updated_org_unit = org_unit_schema.load(json_data, instance=org_unit)
+            updated_org_unit = org_unit_schema.load(
+                json_data, instance=org_unit
+            )
             updated_org_unit.context = {"current_id": unit_id}
             updated_org_unit.update_path_and_level()
             db.session.commit()
@@ -171,7 +177,9 @@ class OrganizationUnitResource(Resource):
             return {"error": str(err)}, 400
         except IntegrityError as err:
             db.session.rollback()
-            logger.error("Integrity error, possibly duplicate entry: %s", str(err))
+            logger.error(
+                "Integrity error, possibly duplicate entry: %s", str(err)
+            )
             return {"error": "Integrity error, possibly duplicate entry."}, 400
         except SQLAlchemyError as err:
             db.session.rollback()
@@ -198,16 +206,22 @@ class OrganizationUnitResource(Resource):
         """
         logger.info("Partially updating organization unit with ID %s", unit_id)
         json_data = request.get_json()
-        org_unit_schema = OrganizationUnitSchema(session=db.session, partial=True)
+        org_unit_schema = OrganizationUnitSchema(
+            session=db.session, partial=True
+        )
         org_unit_schema.context = {"current_id": unit_id}
         try:
             org_unit = OrganizationUnit.get_by_id(unit_id)
             if not org_unit:
-                logger.warning("Organization unit with ID %s not found", unit_id)
+                logger.warning(
+                    "Organization unit with ID %s not found", unit_id
+                )
                 return {"error": "Organization unit not found"}, 404
 
             # Passe le contexte pour la validation de parent_id
-            updated_org_unit = org_unit_schema.load(json_data, instance=org_unit)
+            updated_org_unit = org_unit_schema.load(
+                json_data, instance=org_unit
+            )
             updated_org_unit.update_path_and_level()
             db.session.commit()
             return org_unit_schema.dump(updated_org_unit), 200
@@ -216,7 +230,9 @@ class OrganizationUnitResource(Resource):
             return {"error": str(err)}, 400
         except IntegrityError as err:
             db.session.rollback()
-            logger.error("Integrity error, possibly duplicate entry: %s", str(err))
+            logger.error(
+                "Integrity error, possibly duplicate entry: %s", str(err)
+            )
             return {"error": "Integrity error, possibly duplicate entry."}, 400
         except SQLAlchemyError as err:
             db.session.rollback()
@@ -271,7 +287,9 @@ class OrganizationUnitResource(Resource):
                 "Integrity error while deleting organization unit: %s",
                 str(err),
             )
-            return {"error": "Integrity error, possibly due to FK constraints."}, 400
+            return {
+                "error": "Integrity error, possibly due to FK constraints."
+            }, 400
         except SQLAlchemyError as err:
             db.session.rollback()
             logger.error(
@@ -302,7 +320,9 @@ class OrganizationUnitChildrenResource(Resource):
             tuple: A list of serialized child organization units and HTTP
                    status code 200.
         """
-        logger.info("Retrieving children of organization unit with ID %s", unit_id)
+        logger.info(
+            "Retrieving children of organization unit with ID %s", unit_id
+        )
 
         children = OrganizationUnit.get_children(unit_id)
         org_unit_schema = OrganizationUnitSchema(session=db.session, many=True)

--- a/app/resources/position.py
+++ b/app/resources/position.py
@@ -11,16 +11,16 @@ validation and serialization, and handle database errors gracefully.
 """
 
 from flask import request
+from flask_restful import Resource
 from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from flask_restful import Resource
 
-from app.models import db
 from app.logger import logger
+from app.models import db
+from app.models.organization_unit import OrganizationUnit
 from app.models.position import Position
 from app.schemas.position_schema import PositionSchema
-from app.models.organization_unit import OrganizationUnit
-from app.utils import require_jwt_auth, check_access_required
+from app.utils import check_access_required, require_jwt_auth
 
 
 class PositionListResource(Resource):
@@ -78,7 +78,9 @@ class PositionListResource(Resource):
 
         org_unit = OrganizationUnit.get_by_id(org_unit_id)
         if not org_unit:
-            logger.warning("Organization unit with ID %s not found", org_unit_id)
+            logger.warning(
+                "Organization unit with ID %s not found", org_unit_id
+            )
             return {"message": "Organization unit not found"}, 404
 
         position_schema = PositionSchema(session=db.session)
@@ -282,7 +284,9 @@ class OrganizationUnitPositionsResource(Resource):
         Returns:
             tuple: List of serialized positions and HTTP status code 200.
         """
-        positions = Position.get_by_organization_unit_id(organization_unit_id=unit_id)
+        positions = Position.get_by_organization_unit_id(
+            organization_unit_id=unit_id
+        )
         schema = PositionSchema(many=True)
         return schema.dump(positions), 200
 

--- a/app/resources/subcontractor.py
+++ b/app/resources/subcontractor.py
@@ -9,16 +9,16 @@ updating, and deleting subcontractors. The resources use Marshmallow schemas
 for validation and serialization, and handle database errors gracefully.
 """
 
-from flask import request, g
+from flask import g, request
+from flask_restful import Resource
 from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from flask_restful import Resource
 
-from app.models import db
 from app.logger import logger
+from app.models import db
 from app.models.subcontractor import Subcontractor
 from app.schemas.subcontractor_schema import SubcontractorSchema
-from app.utils import require_jwt_auth, check_access_required
+from app.utils import check_access_required, require_jwt_auth
 
 
 class SubcontractorListResource(Resource):
@@ -127,7 +127,9 @@ class SubcontractorResource(Resource):
 
         subcontractor = Subcontractor.get_by_id(subcontractor_id)
         if not subcontractor:
-            logger.warning("Subcontractor with ID %s not found", subcontractor_id)
+            logger.warning(
+                "Subcontractor with ID %s not found", subcontractor_id
+            )
             return {"message": "Subcontractor not found"}, 404
 
         schema = SubcontractorSchema(session=db.session)
@@ -159,7 +161,9 @@ class SubcontractorResource(Resource):
         try:
             subcontractor = Subcontractor.get_by_id(subcontractor_id)
             if not subcontractor:
-                logger.warning("Subcontractor with ID %s not found", subcontractor_id)
+                logger.warning(
+                    "Subcontractor with ID %s not found", subcontractor_id
+                )
                 return {"message": "Subcontractor not found"}, 404
 
             updated_subcontractor = subcontractor_schema.load(
@@ -197,15 +201,21 @@ class SubcontractorResource(Resource):
                    HTTP status code 404 if the subcontractor is not found.
                    HTTP status code 400 for validation errors.
         """
-        logger.info("Partially updating subcontractor with ID: %s", subcontractor_id)
+        logger.info(
+            "Partially updating subcontractor with ID: %s", subcontractor_id
+        )
 
         json_data = request.get_json()
-        subcontractor_schema = SubcontractorSchema(session=db.session, partial=True)
+        subcontractor_schema = SubcontractorSchema(
+            session=db.session, partial=True
+        )
 
         try:
             subcontractor = Subcontractor.get_by_id(subcontractor_id)
             if not subcontractor:
-                logger.warning("Subcontractor with ID %s not found", subcontractor_id)
+                logger.warning(
+                    "Subcontractor with ID %s not found", subcontractor_id
+                )
                 return {"message": "Subcontractor not found"}, 404
 
             updated_subcontractor = subcontractor_schema.load(
@@ -240,7 +250,9 @@ class SubcontractorResource(Resource):
         """
         subcontractor = Subcontractor.get_by_id(subcontractor_id)
         if not subcontractor:
-            logger.warning("Subcontractor with ID %s not found", subcontractor_id)
+            logger.warning(
+                "Subcontractor with ID %s not found", subcontractor_id
+            )
             return {"message": "Subcontractor not found"}, 404
 
         try:

--- a/app/resources/user_auth.py
+++ b/app/resources/user_auth.py
@@ -9,6 +9,7 @@ related operations.
 """
 
 from datetime import datetime, timezone
+
 from flask import request
 from flask_restful import Resource
 from sqlalchemy.exc import SQLAlchemyError
@@ -66,7 +67,9 @@ class VerifyPasswordResource(Resource):
             db.session.commit()
             logger.info("Updated last_login_at for user %s", email)
         except SQLAlchemyError as e:
-            logger.error("Error updating last_login_at for user %s: %s", email, str(e))
+            logger.error(
+                "Error updating last_login_at for user %s: %s", email, str(e)
+            )
             db.session.rollback()
             # Continue even if update fails - don't block authentication
 

--- a/app/resources/user_avatar.py
+++ b/app/resources/user_avatar.py
@@ -6,13 +6,14 @@ It proxies requests to the Storage Service to get the avatar image.
 """
 
 import os
+
 import requests
 from flask import Response
 from flask_restful import Resource
 
 from app.logger import logger
 from app.models.user import User
-from app.utils import require_jwt_auth, check_access_required
+from app.utils import check_access_required, require_jwt_auth
 
 
 class UserAvatarResource(Resource):
@@ -112,13 +113,17 @@ class UserAvatarResource(Resource):
                 logger.error(
                     f"Storage Service returned {response.status_code}: {response.text}"
                 )
-                return {"message": "Failed to retrieve avatar"}, response.status_code
+                return {
+                    "message": "Failed to retrieve avatar"
+                }, response.status_code
 
             # Stream the file back to the client
             logger.info(f"Serving avatar for user {user_id}")
             return Response(
                 response.iter_content(chunk_size=8192),
-                content_type=response.headers.get("Content-Type", "image/jpeg"),
+                content_type=response.headers.get(
+                    "Content-Type", "image/jpeg"
+                ),
                 headers={
                     "Content-Disposition": response.headers.get(
                         "Content-Disposition", "inline"

--- a/app/resources/user_permissions.py
+++ b/app/resources/user_permissions.py
@@ -10,14 +10,13 @@ through their role and policy assignments.
 
 import os
 
-from flask import request, g
+import requests
+from flask import g, request
 from flask_restful import Resource
 
-import requests
-
 from app.logger import logger
-from app.utils import require_jwt_auth, check_access_required
 from app.models.user import User
+from app.utils import check_access_required, require_jwt_auth
 
 
 class UserPermissionsResource(Resource):
@@ -97,11 +96,15 @@ class UserPermissionsResource(Resource):
                 timeout=5,
             )
         except requests.exceptions.RequestException as e:
-            logger.error("Error contacting Guardian service for roles: %s", str(e))
+            logger.error(
+                "Error contacting Guardian service for roles: %s", str(e)
+            )
             return {"message": "Error fetching user roles"}, 500
 
         if roles_response.status_code != 200:
-            logger.error("Error fetching roles from Guardian: %s", roles_response.text)
+            logger.error(
+                "Error fetching roles from Guardian: %s", roles_response.text
+            )
             return {"message": "Error fetching user roles"}, 500
 
         roles_data = roles_response.json()
@@ -142,7 +145,9 @@ class UserPermissionsResource(Resource):
                 continue
 
             if policies_response.status_code == 404:
-                logger.warning("Role %s not found in Guardian, skipping", role_id)
+                logger.warning(
+                    "Role %s not found in Guardian, skipping", role_id
+                )
                 continue
 
             if policies_response.status_code != 200:
@@ -163,7 +168,9 @@ class UserPermissionsResource(Resource):
             # Handle response format
             if isinstance(policies_data, list):
                 policies = policies_data
-            elif isinstance(policies_data, dict) and "policies" in policies_data:
+            elif (
+                isinstance(policies_data, dict) and "policies" in policies_data
+            ):
                 policies = policies_data.get("policies", [])
             else:
                 logger.warning(
@@ -199,7 +206,9 @@ class UserPermissionsResource(Resource):
                 continue
 
             if permissions_response.status_code == 404:
-                logger.warning("Policy %s not found in Guardian, skipping", policy_id)
+                logger.warning(
+                    "Policy %s not found in Guardian, skipping", policy_id
+                )
                 continue
 
             if permissions_response.status_code != 200:
@@ -221,7 +230,8 @@ class UserPermissionsResource(Resource):
             if isinstance(permissions_data, list):
                 permissions = permissions_data
             elif (
-                isinstance(permissions_data, dict) and "permissions" in permissions_data
+                isinstance(permissions_data, dict)
+                and "permissions" in permissions_data
             ):
                 permissions = permissions_data.get("permissions", [])
             else:

--- a/app/resources/user_policies.py
+++ b/app/resources/user_policies.py
@@ -10,14 +10,13 @@ through their role assignments.
 
 import os
 
-from flask import request, g
+import requests
+from flask import g, request
 from flask_restful import Resource
 
-import requests
-
 from app.logger import logger
-from app.utils import require_jwt_auth, check_access_required
 from app.models.user import User
+from app.utils import check_access_required, require_jwt_auth
 
 
 class UserPoliciesResource(Resource):
@@ -96,11 +95,15 @@ class UserPoliciesResource(Resource):
                 timeout=5,
             )
         except requests.exceptions.RequestException as e:
-            logger.error("Error contacting Guardian service for roles: %s", str(e))
+            logger.error(
+                "Error contacting Guardian service for roles: %s", str(e)
+            )
             return {"message": "Error fetching user roles"}, 500
 
         if roles_response.status_code != 200:
-            logger.error("Error fetching roles from Guardian: %s", roles_response.text)
+            logger.error(
+                "Error fetching roles from Guardian: %s", roles_response.text
+            )
             return {"message": "Error fetching user roles"}, 500
 
         roles_data = roles_response.json()
@@ -144,7 +147,9 @@ class UserPoliciesResource(Resource):
                 continue
 
             if policies_response.status_code == 404:
-                logger.warning("Role %s not found in Guardian, skipping", role_id)
+                logger.warning(
+                    "Role %s not found in Guardian, skipping", role_id
+                )
                 continue
 
             if policies_response.status_code != 200:
@@ -166,7 +171,9 @@ class UserPoliciesResource(Resource):
             # Handle response format (expecting a list of policies)
             if isinstance(policies_data, list):
                 policies = policies_data
-            elif isinstance(policies_data, dict) and "policies" in policies_data:
+            elif (
+                isinstance(policies_data, dict) and "policies" in policies_data
+            ):
                 policies = policies_data.get("policies", [])
             else:
                 logger.warning(

--- a/app/resources/user_position.py
+++ b/app/resources/user_position.py
@@ -8,13 +8,12 @@ It provides endpoints for retrieving users associated with specific positions.
 """
 
 from flask_restful import Resource
-
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.logger import logger
-from app.utils import require_jwt_auth, check_access_required
 from app.models.user import User
 from app.schemas.user_schema import UserSchema
+from app.utils import check_access_required, require_jwt_auth
 
 
 class UserPositionResource(Resource):

--- a/app/resources/version.py
+++ b/app/resources/version.py
@@ -7,13 +7,17 @@ through a REST endpoint.
 """
 
 import os
+
 from flask_restful import Resource
-from app.utils import require_jwt_auth, check_access_required
+
+from app.utils import check_access_required, require_jwt_auth
 
 
 def _read_version():
     """Read version from VERSION file."""
-    version_file_path = os.path.join(os.path.dirname(__file__), "..", "..", "VERSION")
+    version_file_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "VERSION"
+    )
     try:
         with open(version_file_path, "r", encoding="utf-8") as f:
             return f.read().strip()

--- a/app/routes.py
+++ b/app/routes.py
@@ -11,40 +11,35 @@ Functions:
 """
 
 from flask_restful import Api
+
 from app.logger import logger
-from app.resources.version import VersionResource
-from app.resources.config import ConfigResource
 from app.resources.company import CompanyListResource, CompanyResource
+from app.resources.config import ConfigResource
 from app.resources.customer import CustomerListResource, CustomerResource
+from app.resources.health import HealthResource
+from app.resources.init_db import InitDBResource
 from app.resources.organization_unit import (
+    OrganizationUnitChildrenResource,
     OrganizationUnitListResource,
     OrganizationUnitResource,
-    OrganizationUnitChildrenResource,
 )
 from app.resources.position import (
+    OrganizationUnitPositionsResource,
     PositionListResource,
     PositionResource,
-    OrganizationUnitPositionsResource,
 )
 from app.resources.subcontractor import (
     SubcontractorListResource,
     SubcontractorResource,
 )
-from app.resources.user import (
-    UserListResource,
-    UserResource,
-)
-from app.resources.user_avatar import UserAvatarResource
-from app.resources.user_position import UserPositionResource
-from app.resources.user_roles import (
-    UserRolesListResource,
-    UserRolesResource,
-)
-from app.resources.user_policies import UserPoliciesResource
-from app.resources.user_permissions import UserPermissionsResource
+from app.resources.user import UserListResource, UserResource
 from app.resources.user_auth import VerifyPasswordResource
-from app.resources.init_db import InitDBResource
-from app.resources.health import HealthResource
+from app.resources.user_avatar import UserAvatarResource
+from app.resources.user_permissions import UserPermissionsResource
+from app.resources.user_policies import UserPoliciesResource
+from app.resources.user_position import UserPositionResource
+from app.resources.user_roles import UserRolesListResource, UserRolesResource
+from app.resources.version import VersionResource
 
 
 def register_routes(app):
@@ -73,7 +68,9 @@ def register_routes(app):
     api.add_resource(CustomerResource, "/customers/<string:customer_id>")
 
     api.add_resource(OrganizationUnitListResource, "/organization_units")
-    api.add_resource(OrganizationUnitResource, "/organization_units/<string:unit_id>")
+    api.add_resource(
+        OrganizationUnitResource, "/organization_units/<string:unit_id>"
+    )
     api.add_resource(
         OrganizationUnitChildrenResource,
         "/organization_units/<string:unit_id>/children",
@@ -87,7 +84,9 @@ def register_routes(app):
     )
 
     api.add_resource(SubcontractorListResource, "/subcontractors")
-    api.add_resource(SubcontractorResource, "/subcontractors/<string:subcontractor_id>")
+    api.add_resource(
+        SubcontractorResource, "/subcontractors/<string:subcontractor_id>"
+    )
 
     api.add_resource(UserListResource, "/users")
     api.add_resource(UserResource, "/users/<string:user_id>")
@@ -98,9 +97,13 @@ def register_routes(app):
         "/users/<string:user_id>/roles/<string:user_role_id>",
     )
     api.add_resource(UserPoliciesResource, "/users/<string:user_id>/policies")
-    api.add_resource(UserPermissionsResource, "/users/<string:user_id>/permissions")
+    api.add_resource(
+        UserPermissionsResource, "/users/<string:user_id>/permissions"
+    )
 
-    api.add_resource(UserPositionResource, "/positions/<string:position_id>/users")
+    api.add_resource(
+        UserPositionResource, "/positions/<string:position_id>/users"
+    )
     api.add_resource(VerifyPasswordResource, "/verify_password")
 
     logger.info("Routes registered successfully.")

--- a/app/schemas/company_schema.py
+++ b/app/schemas/company_schema.py
@@ -10,8 +10,9 @@ constraints, formats (email, URL, digits), and ensures the uniqueness of the
 company name.
 """
 
+from marshmallow import RAISE, ValidationError, fields, validate, validates
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
-from marshmallow import fields, validate, RAISE, validates, ValidationError
+
 from app.models.company import Company
 
 
@@ -72,12 +73,16 @@ class CompanySchema(SQLAlchemyAutoSchema):
         allow_none=True,
         validate=[
             validate.Length(max=20),
-            validate.Regexp(r"^\d*$", error="Phone number must contain only digits."),
+            validate.Regexp(
+                r"^\d*$", error="Phone number must contain only digits."
+            ),
         ],
     )
     email = fields.Email(allow_none=True, validate=validate.Length(max=255))
     address = fields.String(allow_none=True, validate=validate.Length(max=255))
-    postal_code = fields.String(allow_none=True, validate=validate.Length(max=20))
+    postal_code = fields.String(
+        allow_none=True, validate=validate.Length(max=20)
+    )
     city = fields.String(allow_none=True, validate=validate.Length(max=100))
     country = fields.String(allow_none=True, validate=validate.Length(max=100))
 
@@ -98,6 +103,7 @@ class CompanySchema(SQLAlchemyAutoSchema):
             self.context.get("company") if hasattr(self, "context") else None
         )
         if company and (
-            not current_company or company.id != getattr(current_company, "id", None)
+            not current_company
+            or company.id != getattr(current_company, "id", None)
         ):
             raise ValidationError("Company name must be unique.")

--- a/app/schemas/customer_schema.py
+++ b/app/schemas/customer_schema.py
@@ -10,8 +10,8 @@ Customer model, ensuring data integrity and proper formatting when handling API
 input and output.
 """
 
+from marshmallow import RAISE, fields, validate
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
-from marshmallow import fields, validate, RAISE
 
 from app.models.customer import Customer
 
@@ -51,7 +51,9 @@ class CustomerSchema(SQLAlchemyAutoSchema):
         dump_only = ("id", "created_at", "updated_at")
         unknown = RAISE
 
-    name = fields.String(required=True, validate=validate.Length(min=1, max=100))
+    name = fields.String(
+        required=True, validate=validate.Length(min=1, max=100)
+    )
 
     company_id = fields.String(
         required=True,
@@ -60,13 +62,17 @@ class CustomerSchema(SQLAlchemyAutoSchema):
 
     email = fields.Email(allow_none=True, validate=validate.Length(max=100))
 
-    contact_person = fields.String(allow_none=True, validate=validate.Length(max=100))
+    contact_person = fields.String(
+        allow_none=True, validate=validate.Length(max=100)
+    )
 
     phone_number = fields.String(
         allow_none=True,
         validate=[
             validate.Length(max=50),
-            validate.Regexp(r"^\d*$", error="Phone number must contain only digits."),
+            validate.Regexp(
+                r"^\d*$", error="Phone number must contain only digits."
+            ),
         ],
     )
 

--- a/app/schemas/organization_unit_schema.py
+++ b/app/schemas/organization_unit_schema.py
@@ -11,8 +11,9 @@ handling API input and output.
 """
 
 from typing import Any, Dict
+
+from marshmallow import RAISE, ValidationError, fields, validate, validates
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
-from marshmallow import RAISE, fields, validate, validates, ValidationError
 
 from app.models.organization_unit import OrganizationUnit
 
@@ -111,7 +112,9 @@ class OrganizationUnitSchema(SQLAlchemyAutoSchema):
         # Prevent a node from being its own parent
         context = getattr(self, "context", {}) or {}
         if context.get("current_id") and value == context["current_id"]:
-            raise ValidationError("An organization unit cannot be its own parent.")
+            raise ValidationError(
+                "An organization unit cannot be its own parent."
+            )
 
         # Prevent cycles (parent_id must not be a descendant)
         current_id = context.get("current_id")

--- a/app/schemas/position_schema.py
+++ b/app/schemas/position_schema.py
@@ -10,8 +10,8 @@ Position model, ensuring data integrity and proper formatting when handling API
 input and output.
 """
 
-from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from marshmallow import fields, validate
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 
 from app.models.position import Position
 
@@ -86,5 +86,7 @@ class PositionSchema(SQLAlchemyAutoSchema):
 
     level = fields.Integer(
         required=False,
-        validate=validate.Range(min=0, error="Level must be a positive integer."),
+        validate=validate.Range(
+            min=0, error="Level must be a positive integer."
+        ),
     )

--- a/app/schemas/subcontractor_schema.py
+++ b/app/schemas/subcontractor_schema.py
@@ -10,8 +10,8 @@ Subcontractor model, ensuring data integrity and proper formatting when
 handling API input and output.
 """
 
+from marshmallow import ValidationError, fields, validate, validates
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
-from marshmallow import ValidationError, validate, fields, validates
 
 from app.logger import logger
 from app.models.subcontractor import Subcontractor
@@ -89,13 +89,17 @@ class SubcontractorSchema(SQLAlchemyAutoSchema):
         allow_none=True,
         validate=[
             validate.Length(max=50),
-            validate.Regexp(r"^\d*$", error="Phone number must contain only digits."),
+            validate.Regexp(
+                r"^\d*$", error="Phone number must contain only digits."
+            ),
         ],
     )
 
     email = fields.Email(
         required=False,
-        validate=validate.Length(max=100, error="Email cannot exceed 100 characters."),
+        validate=validate.Length(
+            max=100, error="Email cannot exceed 100 characters."
+        ),
     )
 
     address = fields.String(

--- a/app/storage_helper.py
+++ b/app/storage_helper.py
@@ -7,12 +7,15 @@ Provides avatar upload/delete functionality for the Identity Service.
 """
 
 import os
+
 import requests
 
 from app.logger import logger
 
 # Configuration
-STORAGE_SERVICE_URL = os.getenv("STORAGE_SERVICE_URL", "http://storage-service:5000")
+STORAGE_SERVICE_URL = os.getenv(
+    "STORAGE_SERVICE_URL", "http://storage-service:5000"
+)
 REQUEST_TIMEOUT = int(os.getenv("STORAGE_REQUEST_TIMEOUT", "30"))
 MAX_AVATAR_SIZE = int(os.getenv("MAX_AVATAR_SIZE_MB", "5")) * 1024 * 1024
 
@@ -71,7 +74,11 @@ def validate_avatar(
 
 
 def _prepare_avatar_upload_request(
-    user_id: str, company_id: str, file_data: bytes, content_type: str, filename: str
+    user_id: str,
+    company_id: str,
+    file_data: bytes,
+    content_type: str,
+    filename: str,
 ):
     """Prepare upload request data for avatar."""
     extension = filename.rsplit(".", 1)[-1] if "." in filename else "jpg"
@@ -148,7 +155,9 @@ def upload_avatar_via_proxy(
     logger.debug(f"Uploading avatar for user {user_id} to {url}")
 
     try:
-        logger.info(f"Uploading avatar for user {user_id}: {len(file_data)} bytes")
+        logger.info(
+            f"Uploading avatar for user {user_id}: {len(file_data)} bytes"
+        )
 
         response = requests.post(
             url,
@@ -158,7 +167,9 @@ def upload_avatar_via_proxy(
             timeout=REQUEST_TIMEOUT,
         )
 
-        logger.debug(f"Storage Service response status: {response.status_code}")
+        logger.debug(
+            f"Storage Service response status: {response.status_code}"
+        )
 
         # Accept both 200 and 201 as success
         if response.status_code not in (200, 201):
@@ -296,7 +307,9 @@ def create_user_directories(user_id: str, company_id: str) -> None:
         }
 
         try:
-            logger.info(f"Creating directory marker: {logical_path} for user {user_id}")
+            logger.info(
+                f"Creating directory marker: {logical_path} for user {user_id}"
+            )
 
             response = requests.post(
                 url,
@@ -314,7 +327,9 @@ def create_user_directories(user_id: str, company_id: str) -> None:
             raise StorageServiceError("Storage Service timeout") from None
 
         except requests.exceptions.RequestException as e:
-            logger.error(f"Error creating directory marker {logical_path}: {e}")
+            logger.error(
+                f"Error creating directory marker {logical_path}: {e}"
+            )
             if hasattr(e, "response") and e.response is not None:
                 try:
                     error_data = e.response.json()
@@ -403,7 +418,10 @@ def delete_user_storage(user_id: str, company_id: str) -> None:
                         f"Failed to delete file {file_id}: {del_response.status_code}"
                     )
 
-            except (requests.exceptions.RequestException, ValueError) as file_error:
+            except (
+                requests.exceptions.RequestException,
+                ValueError,
+            ) as file_error:
                 logger.warning(f"Error deleting file {file_id}: {file_error}")
                 # Continue with next file
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,9 +4,10 @@ import os
 import re
 import uuid
 from functools import wraps
+
 import jwt
-from flask import request, g
 import requests
+from flask import g, request
 
 from app.logger import logger
 
@@ -99,7 +100,9 @@ def require_jwt_auth():
                 if user_id:
                     # Create mock JWT data from headers (for testing)
                     jwt_data = {"user_id": user_id, "company_id": company_id}
-                    logger.debug("Using headers for authentication (testing mode)")
+                    logger.debug(
+                        "Using headers for authentication (testing mode)"
+                    )
                 else:
                     return {"message": "Missing or invalid JWT token"}, 401
 
@@ -113,7 +116,9 @@ def require_jwt_auth():
 
             if not company_id:
                 logger.error("company_id missing in JWT token")
-                return {"message": "Invalid JWT token: missing company_id"}, 401
+                return {
+                    "message": "Invalid JWT token: missing company_id"
+                }, 401
 
             # Validate UUID format for company_id
             try:
@@ -159,7 +164,9 @@ def check_access_required(operation):
         @wraps(view_func)
         def wrapped(*args, **kwargs):
             resource_name = kwargs.get("resource_name") or (
-                request.view_args.get("resource_name") if request.view_args else None
+                request.view_args.get("resource_name")
+                if request.view_args
+                else None
             )
             # If not found, deduce from the resource class name
             if not resource_name:
@@ -177,10 +184,14 @@ def check_access_required(operation):
             # Essayer d'utiliser les données JWT déjà décodées si disponibles
             if not user_id and hasattr(g, "jwt_data") and g.jwt_data:
                 user_id = g.jwt_data.get("user_id")
-                logger.debug(f"Using user_id from already decoded JWT: {user_id}")
+                logger.debug(
+                    f"Using user_id from already decoded JWT: {user_id}"
+                )
             # Sinon, extraire user_id du cookie JWT
             elif not user_id:
-                logger.debug("User ID not found in g or headers, checking JWT cookie")
+                logger.debug(
+                    "User ID not found in g or headers, checking JWT cookie"
+                )
                 jwt_data = extract_jwt_data()
                 if jwt_data:
                     user_id = jwt_data.get("user_id")
@@ -188,7 +199,9 @@ def check_access_required(operation):
                 else:
                     logger.warning("JWT token not found or invalid")
             if not user_id or not resource_name:
-                logger.warning("Missing user_id or resource_name for access check.")
+                logger.warning(
+                    "Missing user_id or resource_name for access check."
+                )
                 return {
                     "error": "Missing user_id or resource_name for access check."
                 }, 400
@@ -245,7 +258,9 @@ def check_access(user_id, resource_name, operation):
                 logger.debug("Forwarding JWT cookie to Guardian service")
         except RuntimeError:
             # No request context available (e.g., during testing without Flask app context)
-            logger.debug("No request context available, skipping JWT cookie forwarding")
+            logger.debug(
+                "No request context available, skipping JWT cookie forwarding"
+            )
 
         response = requests.post(
             f"{guardian_service_url}/check-access",
@@ -272,7 +287,9 @@ def check_access(user_id, resource_name, operation):
             # Guardian service returned a 400 with detailed error message
             try:
                 response_data = response.json()
-                logger.warning(f"Guardian service returned 400: {response_data}")
+                logger.warning(
+                    f"Guardian service returned 400: {response_data}"
+                )
                 return (
                     response_data.get("access_granted", False),
                     response_data.get("reason", "Bad request"),


### PR DESCRIPTION
## Description

This PR implements role enrichment for the `GET /users/{id}/roles` endpoint to align its behavior with `/users/{id}/policies` and `/users/{id}/permissions` endpoints.

## Problem
Issue #64 - The `/users/{id}/roles` endpoint was returning junction table records (user-role assignments) instead of full role objects, making it inconsistent with the policies and permissions endpoints which already enriched their responses.

## Solution
- Fetches user-role junction records from Guardian `/user-roles` endpoint
- For each unique `role_id`, fetches the full role object from Guardian `/roles/{role_id}`
- Deduplicates roles when the same role_id appears multiple times
- Handles errors gracefully (404, 500, network errors) by skipping failed roles
- Supports both Guardian response formats (direct list and object with roles key)

## Code Quality Improvements
Refactored the `get()` method to reduce complexity:
- Extracted 4 helper methods: `_get_guardian_headers()`, `_fetch_user_roles_from_guardian()`, `_fetch_role_details()`, `_enrich_roles()`
- Reduced complexity metrics by ~60%:
  - Local variables: 19 → 8
  - Branches: 16 → 8
  - Statements: 57 → 24
- Pylint rating: **10.00/10** ✅

## Testing
- Updated 2 existing tests for new enriched format
- Added 3 new comprehensive edge case tests:
  - `test_get_user_roles_enrichment_with_duplicates` - Deduplication
  - `test_get_user_roles_enrichment_role_not_found` - 404 handling
  - `test_get_user_roles_enrichment_guardian_error` - 500 handling
- Updated 4 tests in `test_guardian_formats.py` to mock enrichment
- Updated 1 test in `test_jwt_forwarding.py` to mock enrichment
- Updated 1 test in `test_simple_guardian.py` to mock enrichment
- **All 304 tests passing** ✅

## Breaking Changes
⚠️ **Yes** - Response format changes from junction records to enriched role objects.

### Before:
```json
{
  "roles": [
    {"id": "ur-123", "user_id": "u-456", "role_id": "admin"},
    {"id": "ur-789", "user_id": "u-456", "role_id": "user"}
  ]
}
```

### After:
```json
{
  "roles": [
    {"id": "admin", "name": "Admin", "description": "Administrator role"},
    {"id": "user", "name": "User", "description": "Regular user role"}
  ]
}
```

## Files Changed
- `app/resources/user_roles.py` - Main implementation
- `tests/test_user.py` - Updated + new tests
- `tests/test_guardian_formats.py` - Updated for enrichment
- `tests/test_jwt_forwarding.py` - Updated for enrichment
- `tests/test_simple_guardian.py` - Updated for enrichment
- Plus formatage automatique (38 fichiers au total)

Closes #64