### PR TITLE
fix: Update integration test for enriched roles format

### DIFF
--- a/tests/integration/test_guardian_integration.py
+++ b/tests/integration/test_guardian_integration.py
@@ -248,13 +248,16 @@ def test_user_roles_endpoint_integration(
         len(data["roles"]) > 0
     ), "User should have at least one role (companyadmin)"
 
-    # Verify role structure
+    # Verify enriched role structure (Issue #64: roles are now enriched objects)
     for role in data["roles"]:
-        assert "role_id" in role, "Each role should have a 'role_id' field"
         assert "id" in role, "Each role should have an 'id' field"
+        assert "name" in role, "Each role should have a 'name' field"
+        # Optional fields that may be present
+        # assert "description" in role, "Each role should have a 'description' field"
+        # assert "company_id" in role, "Each role should have a 'company_id' field"
 
-    role_ids = [role["role_id"] for role in data["roles"]]
-    print(f"✅ User roles retrieved: {len(role_ids)} roles")
+    role_ids = [role["id"] for role in data["roles"]]
+    print(f"✅ User roles retrieved: {len(role_ids)} enriched roles")
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## 📋 Description

Follows up on PR #66 (Issue #64).

The integration test `test_user_roles_endpoint_integration` was failing because it expected the old junction table format with `role_id` field, but after PR #66, `GET /users/{id}/roles` now returns **enriched role objects** instead.

## 🔧 Changes

Updated test assertions in `tests/integration/test_guardian_integration.py`:

**Before (old format - junction table)**:
```python
assert "role_id" in role  # Expected junction record
role_ids = [role["role_id"] for role in data["roles"]]
```

**After (new format - enriched roles)**:
```python
assert "id" in role       # Enriched role object
assert "name" in role     # With full details
role_ids = [role["id"] for role in data["roles"]]
```

## ✅ Testing

- ✅ All 35 integration tests passing
- ✅ All 387 unit tests passing

## 📝 Related

- Fixes the integration test broken by PR #66
- Issue #64: Enrich /users/{id}/roles endpoint