### PR TITLE
docs: Update OpenAPI specification for Issue #64 and init-db endpoint

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2519,22 +2519,138 @@ paths:
 
     post:
       tags: [System]
-      summary: Initialize database with default permissions
-      description: Initialize the database with default permissions if not already done
+      summary: Initialize database with company and admin user
+      description: |
+        Initialize the database with a company, default organization unit, default position, and admin user.
+        
+        This endpoint is intended to be called only once on a fresh database.
+        It creates all entities atomically in a single transaction:
+        1. Company (from request body)
+        2. Default organization unit (auto-created with name "default organization")
+        3. Default position (auto-created with title "Administrator")
+        4. Admin user (from request body, linked to the position)
+        
+        The endpoint will return 403 if the database is already initialized (contains any company or user).
       security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - company
+                - user
+              properties:
+                company:
+                  $ref: '#/components/schemas/CompanyCreate'
+                user:
+                  allOf:
+                    - $ref: '#/components/schemas/UserCreate'
+                    - type: object
+                      required:
+                        - password
+                      properties:
+                        password:
+                          type: string
+                          description: Plain password (will be hashed automatically)
+                          minLength: 8
+            example:
+              company:
+                name: "ACME Corporation"
+                email: "contact@acme.com"
+                phone_number: "1234567890"
+                address: "123 Main Street"
+                city: "New York"
+                postal_code: "10001"
+                country: "USA"
+              user:
+                email: "admin@acme.com"
+                password: "SecurePassword123!"
+                first_name: "John"
+                last_name: "Doe"
+                is_active: true
+                is_verified: true
       responses:
-        '200':
+        '201':
           description: Database initialized successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InitDbResponse'
-        '409':
+                type: object
+                properties:
+                  company:
+                    $ref: '#/components/schemas/Company'
+                  organization_unit:
+                    $ref: '#/components/schemas/OrganizationUnit'
+                  position:
+                    $ref: '#/components/schemas/Position'
+                  user:
+                    $ref: '#/components/schemas/User'
+              example:
+                company:
+                  id: "550e8400-e29b-41d4-a716-446655440000"
+                  name: "ACME Corporation"
+                  email: "contact@acme.com"
+                  phone_number: "1234567890"
+                  address: "123 Main Street"
+                  city: "New York"
+                  postal_code: "10001"
+                  country: "USA"
+                  has_logo: false
+                  created_at: "2024-01-15T10:30:00Z"
+                  updated_at: "2024-01-15T10:30:00Z"
+                organization_unit:
+                  id: "660e8400-e29b-41d4-a716-446655440001"
+                  name: "default organization"
+                  company_id: "550e8400-e29b-41d4-a716-446655440000"
+                  path: "/default organization"
+                  level: 0
+                  created_at: "2024-01-15T10:30:00Z"
+                  updated_at: "2024-01-15T10:30:00Z"
+                position:
+                  id: "770e8400-e29b-41d4-a716-446655440002"
+                  title: "Administrator"
+                  company_id: "550e8400-e29b-41d4-a716-446655440000"
+                  organization_unit_id: "660e8400-e29b-41d4-a716-446655440001"
+                  level: 0
+                  created_at: "2024-01-15T10:30:00Z"
+                  updated_at: "2024-01-15T10:30:00Z"
+                user:
+                  id: "880e8400-e29b-41d4-a716-446655440003"
+                  email: "admin@acme.com"
+                  first_name: "John"
+                  last_name: "Doe"
+                  company_id: "550e8400-e29b-41d4-a716-446655440000"
+                  position_id: "770e8400-e29b-41d4-a716-446655440002"
+                  is_active: true
+                  is_verified: true
+                  has_avatar: false
+                  created_at: "2024-01-15T10:30:00Z"
+                  updated_at: "2024-01-15T10:30:00Z"
+        '400':
+          description: Validation error or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missing_fields:
+                  value:
+                    message: "'company' and 'user' data are required."
+                validation_error:
+                  value:
+                    message: "Validation error"
+                    errors:
+                      password: ["Missing data for required field."]
+        '403':
           description: Database already initialized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: "Identity already initialized"
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -863,8 +863,44 @@ components:
           enum: [en, fr]
           description: User language (en, fr)
 
+    Role:
+      type: object
+      description: Role object enriched with details from Guardian Service
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the role (from Guardian Service)
+        name:
+          type: string
+          description: Name of the role
+        description:
+          type: string
+          nullable: true
+          description: Optional description of the role
+        company_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Company identifier for multi-tenant isolation (null for global roles)
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the role was created
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp when the role was last updated
+
     UserRole:
       type: object
+      deprecated: true
+      description: |
+        DEPRECATED: This schema represents the junction table format.
+        
+        As of Issue #64, GET /users/{user_id}/roles now returns enriched Role objects
+        instead of UserRole junction table records. Use the Role schema instead.
+        
+        This schema is kept for backward compatibility documentation only.
       properties:
         id:
           type: string
@@ -1323,7 +1359,12 @@ components:
                 example: "User deleted successfully"
 
     UserRoles:
-      description: User roles list
+      description: |
+        User roles list with enriched role objects.
+        
+        As of Issue #64, this endpoint returns full Role objects from Guardian Service
+        instead of junction table records. Each role includes id, name, description,
+        company_id, and timestamps.
       content:
         application/json:
           schema:
@@ -1332,7 +1373,21 @@ components:
               roles:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UserRole'
+                  $ref: '#/components/schemas/Role'
+          example:
+            roles:
+              - id: "550e8400-e29b-41d4-a716-446655440000"
+                name: "companyadmin"
+                description: "Company administrator with full access to company resources"
+                company_id: "987fcdeb-51a2-43d1-9f12-345678901234"
+                created_at: "2024-01-15T10:30:00Z"
+                updated_at: "2024-01-15T10:30:00Z"
+              - id: "660e8400-e29b-41d4-a716-446655440001"
+                name: "projectmanager"
+                description: "Project manager with access to project management features"
+                company_id: "987fcdeb-51a2-43d1-9f12-345678901234"
+                created_at: "2024-02-10T14:20:00Z"
+                updated_at: "2024-02-10T14:20:00Z"
 
     UserRoleCreated:
       description: Role assigned to user successfully
@@ -2677,8 +2732,21 @@ paths:
 
     get:
       tags: [Users]
-      summary: Get user roles
-      description: Returns the list of roles assigned to a user via the Guardian Service (RBAC)
+      summary: Get user roles (enriched)
+      description: |
+        Returns the list of roles assigned to a user via the Guardian Service (RBAC).
+        
+        **Enrichment (Issue #64):**
+        As of Issue #64, this endpoint returns full Role objects instead of junction table records.
+        Each role includes:
+        - id: Role identifier
+        - name: Role name
+        - description: Role description
+        - company_id: Company identifier for multi-tenant isolation
+        - created_at, updated_at: Timestamps
+        
+        The enrichment is performed by fetching role details from Guardian Service
+        for each role_id in the user-role associations.
       responses:
         '200':
           $ref: '#/components/responses/UserRoles'


### PR DESCRIPTION
## Summary
This PR updates the OpenAPI specification to document recent changes:

### 1. Enriched Roles Endpoint (Issue #64)
- Add **Role** schema for enriched role objects from Guardian Service
- Deprecate **UserRole** schema (kept for backward compatibility documentation)
- Update **UserRoles** response to use enriched Role objects
- Add comprehensive examples showing enriched format with id, name, description, company_id, timestamps
- Update GET `/users/{user_id}/roles` description to document enrichment process

### 2. Missing init-db Documentation
- Document required `requestBody` structure (company + user objects)
- Add detailed description of atomic transaction process
- Include comprehensive request/response examples
- Document auto-creation of organization unit and position
- Fix response status code (201 instead of 200 for successful creation)
- Add validation error examples

## Related
- Implements documentation for #64
- Completes PR #66 and PR #67

## Changes
- `openapi.yml`: Added Role schema, updated UserRoles response, documented POST /init-db requestBody

## Testing
- ✅ OpenAPI spec syntax validated
- ✅ All examples match actual API behavior
- ✅ Schemas align with current implementation